### PR TITLE
Répare la recherche autocomplete des questions

### DIFF
--- a/questions/models.py
+++ b/questions/models.py
@@ -38,6 +38,11 @@ class QuestionQuerySet(models.QuerySet):
     def for_difficulty(self, difficulty):
         return self.filter(difficulty=difficulty)
 
+    def public_or_by_author(self, author):
+        return self.filter(
+            ~Q(visibility=constants.VISIBILITY_PRIVATE) | Q(author=author) & Q(visibility=constants.VISIBILITY_PRIVATE)
+        )
+
     def simple_search(self, value):
         search_fields = [
             "text",

--- a/questions/models.py
+++ b/questions/models.py
@@ -38,7 +38,9 @@ class QuestionQuerySet(models.QuerySet):
     def for_difficulty(self, difficulty):
         return self.filter(difficulty=difficulty)
 
-    def public_or_by_author(self, author):
+    def public_or_by_author(self, author=None):
+        if not author:
+            return self.public()
         return self.filter(
             ~Q(visibility=constants.VISIBILITY_PRIVATE) | Q(author=author) & Q(visibility=constants.VISIBILITY_PRIVATE)
         )

--- a/questions/tests.py
+++ b/questions/tests.py
@@ -153,6 +153,7 @@ class QuestionModelHistoryTest(TestCase):
 class QuestionModelQuerySetTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.user_contributor = UserFactory()
         QuestionFactory(validation_status=constants.VALIDATION_STATUS_OK, visibility=constants.VISIBILITY_PUBLIC)
         QuestionFactory(validation_status=constants.VALIDATION_STATUS_OK, visibility=constants.VISIBILITY_HIDDEN)
         QuestionFactory(validation_status=constants.VALIDATION_STATUS_OK, visibility=constants.VISIBILITY_PRIVATE)
@@ -162,6 +163,7 @@ class QuestionModelQuerySetTest(TestCase):
             text="xyz",
             validation_status=constants.VALIDATION_STATUS_NEW,
             visibility=constants.VISIBILITY_PRIVATE,
+            author=cls.user_contributor,
         )
 
     def test_question_validated(self):
@@ -175,6 +177,12 @@ class QuestionModelQuerySetTest(TestCase):
 
     def test_question_public_validated(self):
         self.assertEqual(Question.objects.public().validated().count(), 2)
+
+    def test_public_or_by_author(self):
+        self.assertEqual(Question.objects.public_or_by_author().count(), 4)  # public
+        self.assertEqual(
+            Question.objects.public_or_by_author(author=self.user_contributor).count(), 4 + 1
+        )  # public + author
 
     def test_simple_search(self):
         self.assertEqual(Question.objects.simple_search(value="xy").count(), 1)

--- a/quizs/forms.py
+++ b/quizs/forms.py
@@ -46,7 +46,10 @@ class QuizEditForm(QuizCreateForm):
 
 class QuizQuestionEditForm(forms.ModelForm):
     question = forms.ModelChoiceField(
-        queryset=Question.objects.all(), widget=autocomplete.ModelSelect2(url="questions:search")
+        queryset=Question.objects.all(),
+        widget=autocomplete.ModelSelect2(
+            url="questions:search", attrs={"data-placeholder": "Recherche par ID ou Texte"}
+        ),
     )
 
     class Meta:

--- a/www/questions/views.py
+++ b/www/questions/views.py
@@ -1,7 +1,6 @@
 from dal import autocomplete
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
-from django.db.models import Q
 from django.forms.models import model_to_dict
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -245,9 +244,12 @@ class QuestionCreateView(ContributorUserRequiredMixin, SuccessMessageMixin, Crea
 
 class QuestionAutocomplete(ContributorUserRequiredMixin, autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        qs = Question.objects.all()
+        qs = Question.objects.public_or_by_author(author=self.request.user)
 
         if self.q:
-            qs = qs.filter(Q(id=self.q) | Q(text__icontains=self.q))
+            if self.q.replace(" ", "").isdigit():
+                qs = qs.filter(id=self.q)
+            else:
+                qs = qs.filter(text__icontains=self.q)
 
         return qs


### PR DESCRIPTION
Dans la page quiz.questions, il y a un autocomplete - [django-autocomplete-light](https://django-autocomplete-light.readthedocs.io/en/master/index.html) - qui provoquait des erreurs si du texte était recherché (int expected)

Modifications apportées
- pouvoir chercher par id ou texte
- ne pas renvoyer les questions privées (sauf si l'auteur)
- ajout de tests