### PR TITLE
API : pouvoir ordonner les quizs par id ou publish_date

### DIFF
--- a/api/quizs/test_quiz_api.py
+++ b/api/quizs/test_quiz_api.py
@@ -116,6 +116,16 @@ class QuizApiTest(TestCase):
         self.assertEqual(len(response.data["results"]), 1)  # paginates 1 result per page
         self.assertIsNotNone(response.data["next"])
 
+    def test_quiz_list_order(self):
+        response = self.client.get(reverse("api:quiz-list"), {"order": "id"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertEqual(response.data["results"][0]["id"], self.quiz_2.id)
+        response = self.client.get(reverse("api:quiz-list"), {"order": "-id"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertEqual(response.data["results"][0]["id"], self.quiz_3.id)
+
     # def test_quiz_list_with_question_order(self):
     #     response = self.client.get(reverse("api:quiz-list"), {"question_order": "true"})
     #     self.assertEqual(response.status_code, 200)

--- a/api/quizs/views.py
+++ b/api/quizs/views.py
@@ -1,5 +1,6 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
-from rest_framework import mixins, viewsets
+from rest_framework import filters, mixins, viewsets
 
 from api.quizs.filters import QuizFilter
 from api.quizs.serializers import QuizSerializer
@@ -10,6 +11,8 @@ class QuizViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     queryset = Quiz.objects.public().published()
     serializer_class = QuizSerializer
     filterset_class = QuizFilter
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    ordering_fields = ["id", "publish_date"]
 
     @extend_schema(summary="Lister tous les quiz *publiés*", tags=[Quiz._meta.verbose_name_plural])
     def list(self, request, *args, **kwargs):

--- a/app/settings.py
+++ b/app/settings.py
@@ -322,6 +322,7 @@ DJANGO_TABLES2_PAGE_RANGE = 5
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "ORDERING_PARAM": "order",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
     "DATETIME_FORMAT": "%Y-%m-%d",


### PR DESCRIPTION
- permettre d'ordonner les résultats des quizs par les champs `id` & `publish_date`
  - exemple :  `/quizs/?order=-publish_date`
- ajout de test