### PR TITLE
API : quelques optimizations sur l'endpoint Quiz

### DIFF
--- a/api/quizs/serializers.py
+++ b/api/quizs/serializers.py
@@ -28,6 +28,7 @@ QUIZ_FIELDS = [
     "introduction",
     "conclusion",
     # "questions",
+    # "question_count",
     "tags",
     "difficulty_average",
     "language",
@@ -42,7 +43,6 @@ QUIZ_FIELDS = [
     "publish_date",
     "spotlight",
     # "relationships",
-    # "question_count",
     # "questions_categories_list",
     # "questions_tags_list",
     # "questions_authors_list",
@@ -56,6 +56,11 @@ QUIZ_FIELDS_WITH_QUESTION_COUNT.insert(QUIZ_FIELDS_WITH_QUESTION_COUNT.index("ta
 QUIZ_FIELDS_WITH_QUESTIONS = QUIZ_FIELDS.copy()
 QUIZ_FIELDS_WITH_QUESTIONS.insert(QUIZ_FIELDS_WITH_QUESTIONS.index("tags"), "questions")
 
+QUIZ_FIELDS_WITH_QUESTION_COUNT_AND_QUESTIONS = QUIZ_FIELDS_WITH_QUESTION_COUNT.copy()
+QUIZ_FIELDS_WITH_QUESTION_COUNT_AND_QUESTIONS.insert(
+    QUIZ_FIELDS_WITH_QUESTION_COUNT_AND_QUESTIONS.index("question_count"), "questions"
+)
+
 
 class QuizSerializer(serializers.ModelSerializer):
     # author = UserStringSerializer()
@@ -67,9 +72,11 @@ class QuizSerializer(serializers.ModelSerializer):
 
 
 class QuizWithQuestionSerializer(serializers.ModelSerializer):
+    question_count = serializers.IntegerField(source="questions.count", read_only=True)
+
     class Meta:
         model = Quiz
-        fields = QUIZ_FIELDS_WITH_QUESTIONS
+        fields = QUIZ_FIELDS_WITH_QUESTION_COUNT_AND_QUESTIONS
 
 
 class QuizWithQuestionFullStringSerializer(serializers.ModelSerializer):

--- a/api/quizs/serializers.py
+++ b/api/quizs/serializers.py
@@ -49,16 +49,21 @@ QUIZ_FIELDS = [
     "created",
     "updated",
 ]
-QUIZ_FIELDS_WITH_QUESTIONS = QUIZ_FIELDS
+
+QUIZ_FIELDS_WITH_QUESTION_COUNT = QUIZ_FIELDS.copy()
+QUIZ_FIELDS_WITH_QUESTION_COUNT.insert(QUIZ_FIELDS_WITH_QUESTION_COUNT.index("tags"), "question_count")
+
+QUIZ_FIELDS_WITH_QUESTIONS = QUIZ_FIELDS.copy()
 QUIZ_FIELDS_WITH_QUESTIONS.insert(QUIZ_FIELDS_WITH_QUESTIONS.index("tags"), "questions")
 
 
 class QuizSerializer(serializers.ModelSerializer):
     # author = UserStringSerializer()
+    question_count = serializers.IntegerField(source="questions.count", read_only=True)
 
     class Meta:
         model = Quiz
-        fields = QUIZ_FIELDS
+        fields = QUIZ_FIELDS_WITH_QUESTION_COUNT
 
 
 class QuizWithQuestionSerializer(serializers.ModelSerializer):

--- a/api/quizs/test_quiz_api.py
+++ b/api/quizs/test_quiz_api.py
@@ -81,8 +81,10 @@ class QuizApiTest(TestCase):
         self.assertIsInstance(response.data["results"], list)
         self.assertEqual(len(response.data["results"]), 2)  # 1 quiz not published
         self.assertIsNone(response.data["next"])  # pagination: 100
-        # self.assertEqual(response.data["results"][0]["question_count"], 2)
-        # self.assertEqual(response.data["results"][0]["questions"][0], self.question_2.id)
+        # quiz questions
+        self.assertEqual(response.data["results"][0]["id"], self.quiz_2.id)
+        self.assertEqual(response.data["results"][0]["question_count"], 2)
+        self.assertFalse("question" in response.data["results"][0])
 
     def test_quiz_list_filter_by_language(self):
         response = self.client.get(reverse("api:quiz-list"), {"language": constants.LANGUAGE_ENGLISH})
@@ -142,3 +144,11 @@ class QuizApiTest(TestCase):
     #     self.assertEqual(len(response.data["results"]), 1)  # 1 quiz not published
     #     self.assertEqual(len(response.data["results"][0]["questions"]), 2)
     #     self.assertEqual(response.data["results"][0]["questions"][0]["id"], self.question_2.id)
+
+    def test_quiz_detail(self):
+        response = self.client.get(reverse("api:quiz-detail", args=[self.quiz_2.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.data, dict)
+        # questions
+        self.assertEqual(response.data["question_count"], 2)
+        self.assertEqual(len(response.data["questions"]), 2)

--- a/api/quizs/views.py
+++ b/api/quizs/views.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import filters, mixins, viewsets
 
 from api.quizs.filters import QuizFilter
-from api.quizs.serializers import QuizSerializer
+from api.quizs.serializers import QuizSerializer, QuizWithQuestionSerializer
 from quizs.models import Quiz
 
 
@@ -20,4 +20,5 @@ class QuizViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
 
     @extend_schema(summary="Détail d'un quiz *publié*", tags=[Quiz._meta.verbose_name_plural])
     def retrieve(self, request, *args, **kwargs):
+        self.serializer_class = QuizWithQuestionSerializer
         return super().retrieve(request, args, kwargs)

--- a/api/quizs/views.py
+++ b/api/quizs/views.py
@@ -8,7 +8,7 @@ from quizs.models import Quiz
 
 
 class QuizViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
-    queryset = Quiz.objects.public().published()
+    queryset = Quiz.objects.prefetch_many_to_many().public().published()
     serializer_class = QuizSerializer
     filterset_class = QuizFilter
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]

--- a/core/management/commands/export_data_to_github.py
+++ b/core/management/commands/export_data_to_github.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from api.categories.serializers import CategorySerializer
 from api.glossary.serializers import GlossaryItemSerializer
 from api.questions.serializers import QuestionSerializer
-from api.quizs.serializers import QuizQuestionSerializer, QuizRelationshipSerializer, QuizSerializer
+from api.quizs.serializers import QuizQuestionSerializer, QuizRelationshipSerializer, QuizWithQuestionSerializer
 from api.tags.serializers import TagSerializer
 from api.users.serializers import UserWithCountSerializer
 from categories.models import Category
@@ -141,7 +141,7 @@ class Command(BaseCommand):
                 # data/quizs.yaml
                 start_time = time.time()
                 quizs_yaml = utilities.serialize_model_to_yaml(
-                    model_queryset=quiz_queryset, model_serializer=QuizSerializer
+                    model_queryset=quiz_queryset, model_serializer=QuizWithQuestionSerializer
                 )
                 quizs_element = github.create_file_element(file_path="data/quizs.yaml", file_content=quizs_yaml)
 

--- a/quizs/models.py
+++ b/quizs/models.py
@@ -19,6 +19,9 @@ from tags.models import Tag
 
 
 class QuizQuerySet(models.QuerySet):
+    def prefetch_many_to_many(self):
+        return self.prefetch_related("questions", "tags", "authors", "relationships")
+
     def validated(self):
         return self.filter(validation_status=constants.VALIDATION_STATUS_OK)
 


### PR DESCRIPTION
Modifications sur l'endpoint API /quiz/ : 
- list : ne plus renvoyer la liste des questions, seulement le `question_count`
- détail : renvoyer la liste des questions et le `question_count`
- export des quizs : renvoyer le format "détail"
- ajout d'un prefetch related pour accélerer les requêtes