### PR TITLE
API : récupérer les commentaires publiés d'un quiz

### DIFF
--- a/api/questions/tests.py
+++ b/api/questions/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from contributions.models import Comment
+from contributions.factories import CommentFactory
 from core import constants
 from questions.factories import QuestionFactory
 
@@ -57,19 +57,19 @@ class QuestionCommentApiTest(TestCase):
         cls.question_private_validated = QuestionFactory(
             visibility=constants.VISIBILITY_PRIVATE, validation_status=constants.VALIDATION_STATUS_VALIDATED
         )
-        cls.comment_question_public = Comment.objects.create(
+        cls.comment_question_public = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_public, publish=False
         )
-        cls.comment_question_public_validated = Comment.objects.create(
+        cls.comment_question_public_validated = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_public_validated, publish=False
         )
-        cls.comment_question_public_validated_published = Comment.objects.create(
+        cls.comment_question_public_validated_published = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_public_validated, publish=True
         )
-        cls.comment_question_private_published = Comment.objects.create(
+        cls.comment_question_private_published = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_private, publish=True
         )
-        cls.comment_question_private_validated_published = Comment.objects.create(
+        cls.comment_question_private_validated_published = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_private_validated, publish=True
         )
 
@@ -90,10 +90,10 @@ class QuestionCommentApiTest(TestCase):
             self.assertEqual(response.status_code, 404)
 
     def test_question_comment_list_with_replies(self):
-        Comment.objects.create(
+        CommentFactory(
             parent=self.comment_question_public_validated_published, type=constants.COMMENT_TYPE_REPLY, publish=True
         )
-        Comment.objects.create(
+        CommentFactory(
             parent=self.comment_question_public_validated_published,
             type=constants.COMMENT_TYPE_COMMENT_CONTRIBUTOR,
             publish=False,

--- a/api/questions/tests.py
+++ b/api/questions/tests.py
@@ -58,7 +58,7 @@ class QuestionCommentApiTest(TestCase):
             visibility=constants.VISIBILITY_PRIVATE, validation_status=constants.VALIDATION_STATUS_VALIDATED
         )
         cls.comment_question_public = Comment.objects.create(
-            type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_public, publish=True
+            type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_public, publish=False
         )
         cls.comment_question_public_validated = Comment.objects.create(
             type=constants.COMMENT_TYPE_COMMENT_QUESTION, question=cls.question_public_validated, publish=False

--- a/api/quizs/tests.py
+++ b/api/quizs/tests.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from categories.factories import CategoryFactory
-from contributions.models import Comment
+from contributions.factories import CommentFactory
 from core import constants
 from questions.factories import QuestionFactory
 from quizs.factories import QuizFactory
@@ -166,19 +166,19 @@ class QuizCommentApiTest(TestCase):
         cls.quiz_private_published = QuizFactory(
             name="quiz private published", visibility=constants.VISIBILITY_PRIVATE, publish=True
         )
-        cls.comment_quiz_public = Comment.objects.create(
+        cls.comment_quiz_public = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUIZ, quiz=cls.quiz_public, publish=False
         )
-        cls.comment_quiz_public_published = Comment.objects.create(
+        cls.comment_quiz_public_published = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUIZ, quiz=cls.quiz_public_published, publish=False
         )
-        cls.comment_quiz_public_published_published = Comment.objects.create(
+        cls.comment_quiz_public_published_published = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUIZ, quiz=cls.quiz_public_published, publish=True
         )
-        cls.comment_quiz_private_published = Comment.objects.create(
+        cls.comment_quiz_private_published = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUIZ, quiz=cls.quiz_private, publish=True
         )
-        cls.comment_quiz_private_published_published = Comment.objects.create(
+        cls.comment_quiz_private_published_published = CommentFactory(
             type=constants.COMMENT_TYPE_COMMENT_QUIZ, quiz=cls.quiz_private_published, publish=True
         )
 
@@ -199,10 +199,10 @@ class QuizCommentApiTest(TestCase):
             self.assertEqual(response.status_code, 404)
 
     def test_quiz_comment_list_with_replies(self):
-        Comment.objects.create(
+        CommentFactory(
             parent=self.comment_quiz_public_published_published, type=constants.COMMENT_TYPE_REPLY, publish=True
         )
-        Comment.objects.create(
+        CommentFactory(
             parent=self.comment_quiz_public_published_published,
             type=constants.COMMENT_TYPE_COMMENT_CONTRIBUTOR,
             publish=False,

--- a/api/quizs/views.py
+++ b/api/quizs/views.py
@@ -1,9 +1,13 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters, mixins, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
+from api.contributions.serializers import CommentReadSerializer
 from api.quizs.filters import QuizFilter
 from api.quizs.serializers import QuizSerializer, QuizWithQuestionSerializer
+from contributions.models import Comment
 from quizs.models import Quiz
 
 
@@ -22,3 +26,20 @@ class QuizViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     def retrieve(self, request, *args, **kwargs):
         self.serializer_class = QuizWithQuestionSerializer
         return super().retrieve(request, args, kwargs)
+
+    @extend_schema(
+        summary="Lister tous les commentaires *publiés* d'un quiz *publié*",
+        tags=[Comment._meta.verbose_name_plural],
+    )
+    @action(detail=True, methods=["get"])
+    def contributions(self, request, pk=None):
+        quiz = self.get_object()
+        queryset = quiz.comments_published
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = CommentReadSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = CommentReadSerializer(queryset, many=True)
+        return Response(serializer.data)

--- a/quizs/models.py
+++ b/quizs/models.py
@@ -365,6 +365,10 @@ class Quiz(models.Model):
     def comment_count(self) -> int:
         return self.comments.count()
 
+    @property
+    def comments_published(self):
+        return self.comments.published()
+
     # Admin
     tags_list_string.fget.short_description = _("Tags")
     authors_list_string.fget.short_description = _("Authors")


### PR DESCRIPTION
### Quoi ?

Pour un quiz donnée (publique et publié), nouvel endpoint API pour récupérer ses commentaires publiés
- endpoint : `/api/quizs/<id>/contributions`
- ajout de tests
- utiliser au maximum `CommentFactory`