### PR TITLE
Sendinblue : méthodes pour envoyer des e-mails transactionnels

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -254,16 +254,18 @@ if not DEBUG:
     EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
 
 CONTACT_EMAIL = os.getenv("CONTACT_EMAIL")
-DEFAULT_FROM_EMAIL = "Quiz de l'Anthropocène <noreply@quizanthropocene.fr>"
+DEFAULT_FROM_EMAIL = "noreply@quizanthropocene.fr"
 DEFAULT_FROM_NAME = "Quiz de l'Anthropocène"
 SERVER_EMAIL = os.getenv("TECH_EMAIL")
 ADMINS = eval(os.getenv("ADMINS", "[]"))
 
+SIB_CONTACT_ENDPOINT = "https://api.sendinblue.com/v3/contacts"
+SIB_CONTACT_DOI_ENDPOINT = "https://api.sendinblue.com/v3/contacts/doubleOptinConfirmation"
 SIB_CONTRIBUTOR_LIST_ID = os.getenv("SIB_CONTRIBUTOR_LIST_ID", 0)
 SIB_NEWSLETTER_LIST_ID = os.getenv("SIB_NEWSLETTER_LIST_ID", 0)
 SIB_NEWSLETTER_DOI_TEMPLATE_ID = os.getenv("SIB_NEWSLETTER_DOI_TEMPLATE_ID", 0)
-SIB_CONTACT_ENDPOINT = "https://api.sendinblue.com/v3/contacts"
-SIB_CONTACT_DOI_ENDPOINT = "https://api.sendinblue.com/v3/contacts/doubleOptinConfirmation"
+
+SIB_SMTP_ENDPOINT = "https://api.brevo.com/v3/smtp/email"
 
 
 # Errors

--- a/core/utils/sendinblue.py
+++ b/core/utils/sendinblue.py
@@ -32,6 +32,7 @@ def add_to_contact_list(user, list_id=settings.SIB_CONTRIBUTOR_LIST_ID, extra_at
     if not settings.DEBUG and not settings.TESTING:
         return requests.post(settings.SIB_CONTACT_ENDPOINT, headers=HEADERS, data=json.dumps(data))
     else:
+        print("Sendinblue: user not added to contact list (DEBUT or TESTING environment detected)")
         return True
 
 
@@ -57,4 +58,28 @@ def newsletter_registration(user_email):
     if not settings.DEBUG and not settings.TESTING:
         return requests.post(settings.SIB_CONTACT_DOI_ENDPOINT, headers=HEADERS, data=json.dumps(data))
     else:
+        print("Sendinblue: user not registered to the newsletter (DEBUT or TESTING environment detected)")
+        return True
+
+
+def send_transactional_email_with_template_id(
+    template_id,
+    to_email,
+    to_name,
+    parameters=None,
+    from_email=settings.DEFAULT_FROM_EMAIL,
+    from_name=settings.DEFAULT_FROM_NAME,
+):
+    data = {
+        "sender": {"email": from_email, "name": from_name},  # must be a sender registered and verified in Brevo
+        "to": [{"email": to_email, "name": to_name}],
+        "templateId": template_id,
+    }
+    if parameters:
+        data["params"] = parameters
+
+    if not settings.DEBUG and not settings.TESTING:
+        return requests.post(settings.SIB_SMTP_ENDPOINT, headers=HEADERS, data=json.dumps(data))
+    else:
+        print("Sendinblue: email not sent (DEBUT or TESTING environment detected)")
         return True

--- a/core/utils/sendinblue.py
+++ b/core/utils/sendinblue.py
@@ -63,17 +63,42 @@ def newsletter_registration(user_email):
 
 
 def send_transactional_email_with_template_id(
-    template_id,
     to_email,
     to_name,
+    template_id,
     parameters=None,
     from_email=settings.DEFAULT_FROM_EMAIL,
     from_name=settings.DEFAULT_FROM_NAME,
 ):
     data = {
-        "sender": {"email": from_email, "name": from_name},  # must be a sender registered and verified in Brevo
+        "sender": {"email": from_email, "name": from_name},  # email must be a sender registered and verified in Brevo
         "to": [{"email": to_email, "name": to_name}],
         "templateId": template_id,
+    }
+    if parameters:
+        data["params"] = parameters
+
+    if not settings.DEBUG and not settings.TESTING:
+        return requests.post(settings.SIB_SMTP_ENDPOINT, headers=HEADERS, data=json.dumps(data))
+    else:
+        print("Sendinblue: email not sent (DEBUT or TESTING environment detected)")
+        return True
+
+
+def send_transactional_email_with_html(
+    to_email,
+    to_name,
+    subject,
+    html,
+    parameters=None,
+    from_email=settings.DEFAULT_FROM_EMAIL,
+    from_name=settings.DEFAULT_FROM_NAME,
+):
+    data = {
+        "sender": {"email": from_email, "name": from_name},  # email must be a sender registered and verified in Brevo
+        "to": [{"email": to_email, "name": to_name}],
+        "subject": subject,
+        "htmlContent": html,
     }
     if parameters:
         data["params"] = parameters

--- a/core/utils/sendinblue.py
+++ b/core/utils/sendinblue.py
@@ -32,7 +32,7 @@ def add_to_contact_list(user, list_id=settings.SIB_CONTRIBUTOR_LIST_ID, extra_at
     if not settings.DEBUG and not settings.TESTING:
         return requests.post(settings.SIB_CONTACT_ENDPOINT, headers=HEADERS, data=json.dumps(data))
     else:
-        print("Sendinblue: user not added to contact list (DEBUT or TESTING environment detected)")
+        print("Sendinblue: user not added to contact list (DEBUG or TESTING environment detected)")
         return True
 
 
@@ -58,7 +58,7 @@ def newsletter_registration(user_email):
     if not settings.DEBUG and not settings.TESTING:
         return requests.post(settings.SIB_CONTACT_DOI_ENDPOINT, headers=HEADERS, data=json.dumps(data))
     else:
-        print("Sendinblue: user not registered to the newsletter (DEBUT or TESTING environment detected)")
+        print("Sendinblue: user not registered to the newsletter (DEBUG or TESTING environment detected)")
         return True
 
 
@@ -81,7 +81,7 @@ def send_transactional_email_with_template_id(
     if not settings.DEBUG and not settings.TESTING:
         return requests.post(settings.SIB_SMTP_ENDPOINT, headers=HEADERS, data=json.dumps(data))
     else:
-        print("Sendinblue: email not sent (DEBUT or TESTING environment detected)")
+        print("Sendinblue: email not sent (DEBUG or TESTING environment detected)")
         return True
 
 
@@ -106,5 +106,5 @@ def send_transactional_email_with_html(
     if not settings.DEBUG and not settings.TESTING:
         return requests.post(settings.SIB_SMTP_ENDPOINT, headers=HEADERS, data=json.dumps(data))
     else:
-        print("Sendinblue: email not sent (DEBUT or TESTING environment detected)")
+        print("Sendinblue: email not sent (DEBUG or TESTING environment detected)")
         return True


### PR DESCRIPTION
### Quoi ?

2 nouvelles méthodes pour faciliter l'envoi de-mails transactionnels
- `send_transactional_email_with_template_id`
- `send_transactional_email_with_html`

### Documentation

https://developers.brevo.com/docs/send-a-transactional-email
https://developers.brevo.com/reference/sendtransacemail