### PR TITLE
fix: fix user quiz stats "divide by zero"

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -273,7 +273,9 @@ class User(AbstractUser):
                     quiz.stats.aggregate(Avg("answer_success_count"))["answer_success_count__avg"]
                     / quiz.stats.aggregate(Avg("question_count"))["question_count__avg"]
                 )
-        return round(answer_success_count_ratio / quiz_played_count * 100, 2)
+        if quiz_played_count:
+            return round((answer_success_count_ratio / quiz_played_count) * 100, 2)
+        return 0
 
     @property
     def quiz_like_count(self) -> int:

--- a/users/tests.py
+++ b/users/tests.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from core import constants
 from questions.factories import QuestionFactory
 from quizs.factories import QuizFactory
+from stats.models import QuizAnswerEvent
 from users import constants as user_constants
 from users.factories import UserFactory
 from users.models import User
@@ -31,6 +32,18 @@ class UserModelTest(TestCase):
 
     def test_has_question(self):
         self.assertTrue(self.user.has_question)
+
+    def test_quiz_answer_success_count_ratio(self):
+        self.assertEqual(self.user.quiz_answer_success_count_ratio, 0)
+        # add stats
+        QuizAnswerEvent.objects.create(quiz=self.quiz, answer_success_count=0, question_count=2)
+        self.assertEqual(self.user.quiz_answer_success_count_ratio, 0)
+        QuizAnswerEvent.objects.create(quiz=self.quiz, answer_success_count=1, question_count=2)
+        self.assertEqual(self.user.quiz_answer_success_count_ratio, 25.0)
+        QuizAnswerEvent.objects.create(quiz=self.quiz, answer_success_count=2, question_count=2)
+        self.assertEqual(self.user.quiz_answer_success_count_ratio, 50.0)
+        QuizAnswerEvent.objects.create(quiz=self.quiz, answer_success_count=2, question_count=2)
+        self.assertEqual(self.user.quiz_answer_success_count_ratio, 62.5)
 
 
 class UserModelRoleTest(TestCase):


### PR DESCRIPTION
### What ?

- avoid a `ZeroDivisionError` in `user.quiz_answer_success_count_ratio` property
- update tests