### PR TITLE
refactor(l10n): add Italian, Spanish, German in the language UI dropdown

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -178,9 +178,9 @@ USE_TZ = True
 LANGUAGES = (
     ("en", _("English")),
     ("fr", _("French")),
-    # ("es", _("Spanish")),
-    # ("it", _("Italian")),
-    # ("de", _("German")),
+    ("es", _("Spanish")),
+    ("it", _("Italian")),
+    ("de", _("German")),
 )
 
 LOCALE_PATHS = [


### PR DESCRIPTION
We have these languages in Crowdin. But not yet in the UI dropdown