### PR TITLE
feat(Questions): Admin: new readonly list of all the last changes

### DIFF
--- a/questions/admin.py
+++ b/questions/admin.py
@@ -3,7 +3,8 @@ from io import StringIO
 from django.conf import settings
 from django.contrib import admin
 from django.core import management
-from django.utils.html import mark_safe
+from django.urls import reverse
+from django.utils.html import format_html, mark_safe
 from fieldsets_with_inlines import FieldsetsInlineMixin
 from import_export import fields, resources
 from import_export.admin import ImportMixin
@@ -383,4 +384,57 @@ class QuestionAdmin(ImportMixin, ExportMixin, FieldsetsInlineMixin, SimpleHistor
         return super().changelist_view(request, extra_context=extra_context)
 
 
+class HistoricalQuestionAdmin(admin.ModelAdmin):
+    list_display = [
+        # "history_id",
+        "id",
+        "history_date",
+        "history_type",
+        "history_change_reason",
+        "history_user",
+        # "history_changed_fields",
+    ]
+    search_fields = ["id"]
+    list_filter = ["history_type", "history_date", "history_user"]
+    ordering = ["-history_date"]
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "history_id",
+                    "history_date",
+                    "history_type",
+                    "history_change_reason",
+                    "history_user",
+                    "history_changed_fields",
+                )
+            },
+        ),
+        ("Question", {"fields": ("question_with_link",)}),
+    )
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def question_with_link(self, obj):
+        if obj.id:
+            url = reverse(
+                f"{self.admin_site.name}:{Question._meta.app_label}_{Question._meta.model_name}_change",
+                args=[obj.id],
+            )
+            return format_html(f'<a href="{url}">{obj}</a>')
+
+    question_with_link.short_description = Question._meta.verbose_name
+
+
+HistoricalQuestion = Question.history.model
+
 admin_site.register(Question, QuestionAdmin)
+admin_site.register(HistoricalQuestion, HistoricalQuestionAdmin)

--- a/questions/admin.py
+++ b/questions/admin.py
@@ -386,8 +386,8 @@ class QuestionAdmin(ImportMixin, ExportMixin, FieldsetsInlineMixin, SimpleHistor
 
 class HistoricalQuestionAdmin(admin.ModelAdmin):
     list_display = [
+        "id",  # question id
         # "history_id",
-        "id",
         "history_date",
         "history_type",
         "history_change_reason",


### PR DESCRIPTION
### What

The `Question` model changes are tracked with `django-simple-history`
Display this in a new dedicated admin page

### Screenshot

<img width="1344" height="522" alt="image" src="https://github.com/user-attachments/assets/703da217-3790-44aa-a812-c762e9376051" />
