### PR TITLE
fix(Admin): fieldsets_with_inlines: override template for compatibility with Django 5 (length_is, CSS)

### DIFF
--- a/templates/fieldsets_with_inlines/fieldset.html
+++ b/templates/fieldsets_with_inlines/fieldset.html
@@ -1,0 +1,57 @@
+{% comment %}
+Local override of https://github.com/robertkovac/django-fieldsets-with-inlines/blob/master/fieldsets_with_inlines/templates/fieldsets_with_inlines/fieldset.html
+Why this override exists:
+- The third-party template used the removed Django filter `length_is`, which raises "Invalid filter: 'length_is'" on recent Django versions.
+
+Changes made in this copy:
+- Replaced all `line.fields|length_is:'1'` checks with `line.fields|length == 1`.
+- Migrated row/field wrappers to current Django admin layout classes and structure: `flex-container`, `form-multiline`, and `fieldBox`.
+- Kept checkbox/read-only rendering behavior equivalent to upstream package behavior.
+- Updated help text markup to current admin pattern, including hidden-state class and optional `id="<field>_helptext"` for accessibility.
+- Kept collapsible fieldset handling (`fieldset.is_collapsible`) and heading output.
+
+Goal:
+- Preserve fieldsets-with-inlines behavior while restoring compatibility and visual consistency with the native Django admin layout.
+{% endcomment %}
+<fieldset class="module aligned {{ fieldset.classes }}">
+    {% if fieldset.name %}
+        {% if fieldset.is_collapsible %}<details><summary>{% endif %}
+        <h2 class="fieldset-heading">{{ fieldset.name }}</h2>
+        {% if fieldset.is_collapsible %}</summary>{% endif %}
+    {% endif %}
+
+    {% if fieldset.description %}
+        <div class="description">{{ fieldset.description|safe }}</div>
+    {% endif %}
+
+    {% for line in fieldset %}
+        <div class="form-row{% if line.fields|length == 1 and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+            {% if line.fields|length == 1 %}{{ line.errors }}{% else %}<div class="flex-container form-multiline">{% endif %}
+            {% for field in line %}
+                <div>
+                    {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.errors }}{% endif %}
+                    <div class="flex-container{% if not line.fields|length == 1 %} fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}{% endif %}{% if field.is_checkbox %} checkbox-row{% endif %}">
+                        {% if field.is_checkbox %}
+                            {{ field.field }}{{ field.label_tag }}
+                        {% else %}
+                            {{ field.label_tag }}
+                            {% if field.is_readonly %}
+                                <div class="readonly">{{ field.contents }}</div>
+                            {% else %}
+                                {{ field.field }}
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                    {% if field.field.help_text %}
+                        <div class="help{% if field.field.is_hidden %} hidden{% endif %}"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
+                            <div>{{ field.field.help_text|safe }}</div>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endfor %}
+            {% if not line.fields|length == 1 %}</div>{% endif %}
+        </div>
+    {% endfor %}
+
+    {% if fieldset.name and fieldset.is_collapsible %}</details>{% endif %}
+</fieldset>


### PR DESCRIPTION
### What

In this project we use the [django-fieldsets-with-inlines](https://github.com/robertkovac/django-fieldsets-with-inlines) package. It hasn't been updated in 3 years. And it's not compatible anymore with Django 5.

This PR creates a new templates/fieldsets_with_inlines/fieldset.html to override and fix the compatibility
- replaces the deprecated `length_is` filter
- adapts the HTML/CSS to keep the layout

See https://github.com/robertkovac/django-fieldsets-with-inlines/issues/10

A better solution would be to fork or maintain the package, instead of overriding...
